### PR TITLE
Renomeia chave `indentação` do arquivo config para `recuo`

### DIFF
--- a/.github/workflows/abnt-pandoc.latex
+++ b/.github/workflows/abnt-pandoc.latex
@@ -48,8 +48,8 @@
 \usepackage{ragged2e}
 \usepackage[flushmargin,hang,multiple,bottom]{footmisc}
 \usepackage{indentfirst}
-$if(indentação)$
-   \setlength{\parindent}{$indentação$}
+$if(recuo)$
+   \setlength{\parindent}{$recuo$}
    $else$
    \setlength{\parindent}{1.3cm}
 $endif$ 
@@ -255,7 +255,7 @@ $if(agradecimentos)$
    \addcontentsline{toc}{section}{Agradecimentos}
    \endgroup
 
-   \justifying\setlength{\parindent}{$indentação$}\setlength{\parskip}{0pt}\setstretch{$entrelinhas$}\normalsize\rmfamily\mdseries
+   \justifying\setlength{\parindent}{$recuo$}\setlength{\parskip}{0pt}\setstretch{$entrelinhas$}\normalsize\rmfamily\mdseries
    $agradecimentos$
 $endif$
 

--- a/_config.md
+++ b/_config.md
@@ -17,7 +17,9 @@ margens:
   inferior: 30mm
   esquerda: 30mm
   direita: 30mm
+# Espaçamento entrelinhas
 entrelinhas: 1.3
-indentação: 1.3cm
+# Recuo do início do parágrafo
+recuo: 1.3cm
 dois-lados: false
 ---

--- a/_config.md
+++ b/_config.md
@@ -7,19 +7,24 @@ autor:
   nome: Barbara G. Demartini
   titulação: Doutora em Filosofia pela Hill Valley College.
   afiliação: Hill Valley College (bg.demartini@hillvalleycollege.edu).
+
 resumo: Este hipertexto, isto é, matriz de textos potencializados em um duplo-devir virtualizante, visa proporcionar uma combinatória proto-semântica de um discurso proposicional a partir de um universo de possíveis. Sua instauração epistemológica é traçada a posteriori pela necessidade de construir-se um conhecimento teórico escamoteado em uma base glossofônica da interioridade da razão, em conssonância com a textualidade apofântica sinteticamente determinável em sua exterioridade do Ser. De maneira sucinta, a interioridade do Ser social, eminentemente enquanto Ser, prova que o nominalismo enquanto princípio teórico undefineddo fundo comum da umanidade.
 palavras-chave: Epistemologia. Dialética. Instituição política. Socio-linguistica.
 abstract: This hypertext, that is, a matrix of texts enhanced in a virtualizing double-becoming, aims to provide a proto-semantic combination of a propositional discourse from a universe of possible ones. Its epistemological establishment is traced a posteriori by the need to build theoretical knowledge concealed on a glossophonic basis of the interiority of reason, in consonance with the apophantic textually synthetically determinable in its exteriority of Being. Briefly, the interiority of the social Being, eminently as a Being, proves that nominalism as a theoretical principle undefined in the common fund of humanity.
 keywords: Epistemology. Dialectic. Political institution. Socio-linguistics.
 agradecimentos: Este simulacro individualizante é uma sátira do discurso hermético pós-moderno e não deve, de forma alguma, ser levado em consideração.
+
 margens:
   superior: 30mm
   inferior: 30mm
   esquerda: 30mm
   direita: 30mm
+
 # Espaçamento entrelinhas
 entrelinhas: 1.3
+
 # Recuo do início do parágrafo
 recuo: 1.3cm
+
 dois-lados: false
 ---


### PR DESCRIPTION
Além disso, adiciona comentários explicando o significado das chaves
`entrelinhas` e `recuo`.
Resolve: #1